### PR TITLE
Announce the deprecation of the generation forecast summary endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ These include any part of Insights Solution:
 
 Breaking changes to the Insights Solution and planned outages will be announced here.
 
-## 2024-03-26 Planned outage
+## 2024-10-01 Deprecation of Generation Forecast summary endpoints
 
-Planned infrastructure outage between 4:30 (GMT) to 17:30 (GMT) on Tuesday 26 March 2024 impacting upstream data sent to Insights. During the outage window Insights Platform will not be publishing data via IRIS, website and APIs.
+The following four endpoints are now all deprecated and will be removed in early 2025.
+- `/generation/availability/summary/14D` (currently redirects to `/forecast/availability/summary/14D` below)
+- `/generation/availability/summary/3YW` (currently redirects to `/forecast/availability/summary/3YW` below)
+- `/forecast/availability/summary/14D`
+- `/forecast/availability/summary/3YW`
 
-## 2024-03-27 Breaking change to DISBSAD
-
-We are releasing a breaking change to fix a discrepancy in the DISBSAD data schema between IRIS and the Insights API. IRIS previous returned `IsTendered` as a string with possible values `"Tendered"` or `"Non-tendered"`; after this release it will return a nullable boolean value, where `true` corresponds to `"Tendered"`.
+Users should migrate over to using the following endpoints instead:
+- [`forecast/availability/daily`](https://bmrs.elexon.co.uk/api-documentation/endpoint/forecast/availability/daily)
+- [`forecast/availability/weekly`](https://bmrs.elexon.co.uk/api-documentation/endpoint/forecast/availability/weekly)
 
 # Issues
 


### PR DESCRIPTION
- Removed a couple of announcements about planned outages that are now very much historic
- Added an announcement of the deprecation of the generation forecast summary endpoints